### PR TITLE
unsupport windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,6 @@ build-all:
 		$(call build-artifact,linux,arm)
 		$(call build-artifact,linux,arm64)
 		$(call build-artifact,darwin,amd64)
-		$(call build-artifact,windows,386)
-		$(call build-artifact,windows,amd64)
 
 build:
 		go build -o bin/$(APP) $(MAIN_FILE)


### PR DESCRIPTION
```
GOOS=windows GOARCH=386 go build -o artifacts/lightaws
/home/ubuntu/.go_workspace/src/github.com/spf13/cobra/command_win.go:9:2: cannot find package "github.com/inconshreveable/mousetrap" in any of:
	/usr/local/go/src/github.com/inconshreveable/mousetrap (from $GOROOT)
	/home/ubuntu/.go_workspace/src/github.com/inconshreveable/mousetrap (from $GOPATH)
	/usr/local/go_workspace/src/github.com/inconshreveable/mousetrap
	/home/ubuntu/.go_project/src/github.com/inconshreveable/mousetrap
make: *** [build-all] Error 1
```